### PR TITLE
Adding basic support for Kafka Connect

### DIFF
--- a/grafka/src/main/kotlin/com/grafka/entities/KafkaConnect.kt
+++ b/grafka/src/main/kotlin/com/grafka/entities/KafkaConnect.kt
@@ -1,0 +1,10 @@
+package com.grafka.entities
+
+class KafkaConnect(config: KafkaConnectConfig) {
+    val connectId: String = config.connectId.toString()
+    val name: String = config.name
+    val config: String = config.config
+
+    // TODO connectors
+}
+

--- a/grafka/src/main/kotlin/com/grafka/entities/KafkaConnectConfig.kt
+++ b/grafka/src/main/kotlin/com/grafka/entities/KafkaConnectConfig.kt
@@ -1,0 +1,19 @@
+package com.grafka.entities
+
+import java.util.*
+import javax.persistence.*
+
+@Entity
+@Table(name = "connect_config")
+class KafkaConnectConfig(
+        @Id
+        @org.hibernate.annotations.Type(type = "org.hibernate.type.PostgresUUIDType")
+        @Column(name = "connect_id", nullable = false)
+        var connectId: UUID = UUID(0, 0),
+
+        @Column(name = "name", nullable = false)
+        var name: String = "",
+
+        @Column(name = "config", length = 4096, nullable = false)
+        var config: String = ""
+)

--- a/grafka/src/main/kotlin/com/grafka/repositories/KafkaConnectConfigRepository.kt
+++ b/grafka/src/main/kotlin/com/grafka/repositories/KafkaConnectConfigRepository.kt
@@ -1,0 +1,9 @@
+package com.grafka.repositories
+
+import com.grafka.entities.KafkaConnectConfig
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface KafkaConnectConfigRepository : JpaRepository<KafkaConnectConfig, UUID>

--- a/grafka/src/main/kotlin/com/grafka/resolvers/KafkaConnectResolver.kt
+++ b/grafka/src/main/kotlin/com/grafka/resolvers/KafkaConnectResolver.kt
@@ -1,0 +1,40 @@
+package com.grafka.resolvers
+
+import com.coxautodev.graphql.tools.GraphQLMutationResolver
+import com.coxautodev.graphql.tools.GraphQLQueryResolver
+import com.grafka.entities.KafkaConnect
+import com.grafka.entities.KafkaConnectConfig
+import com.grafka.repositories.KafkaConnectConfigRepository
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class KafkaConnectResolver(private val repository: KafkaConnectConfigRepository) : GraphQLQueryResolver, GraphQLMutationResolver {
+    fun connect(connectId: String?) = connectClusterConfigs(connectId).map { KafkaConnect(it) }
+    fun connectClusterConfigs(connectId: String?) = if (connectId != null) {
+        listOf(repository.findById(UUID.fromString(connectId)).get())
+    } else {
+        repository.findAll()
+    }
+
+    fun newConnect(name: String, config: String): KafkaConnect {
+        val item = KafkaConnectConfig(UUID.randomUUID(), name, config)
+        repository.save(item)
+        return KafkaConnect(item)
+    }
+
+    fun deleteConnect(connectId: String): Boolean {
+        repository.deleteById(UUID.fromString(connectId))
+        return true
+    }
+
+    fun updateConnect(connectId: String, name: String, config: String): KafkaConnect {
+        val item = repository.findById(UUID.fromString(connectId))
+        item.ifPresent {
+            it.name = name
+            it.config = config
+            repository.save(it)
+        }
+        return KafkaConnect(item.get())
+    }
+}

--- a/grafka/src/main/resources/schema.graphqls
+++ b/grafka/src/main/resources/schema.graphqls
@@ -6,6 +6,7 @@ schema {
 
 type Query {
     clusters(clusterId: ID): [KafkaCluster]
+    connect(connectId: ID): [KafkaConnect]
 
     consumerGroupListings(clusterId: ID!, partialConsumerGroupId: String, topicName: String): [KafkaConsumerGroupListing]!
     consumerGroupOffsets(clusterId: String!, groupId: String!): [KafkaOffset!]!
@@ -24,6 +25,11 @@ type Mutation {
     newCluster(name: String!, config: String!): KafkaCluster!
     deleteCluster(clusterId: ID!): Boolean
     updateCluster(clusterId: String!, name: String!, config: String!): KafkaCluster!
+
+    # Connect
+    newConnect(name: String!, config: String!): KafkaConnect!
+    deleteConnect(connectId: ID!): Boolean
+    updateConnect(connectId: String!, name: String!, config: String!): KafkaConnect!
 
     # Topics: Note, not returning TopicListing because topic can be confirmed before it is retrievable
     newTopicByPartitionAndReplicationFactor(clusterId: ID!, topicName: String!, partitionCount: Int!, replicationFactor: Int!, configs: [KafkaTopicConfig]): Boolean
@@ -45,6 +51,12 @@ type KafkaCluster {
     schemaRegistry: KafkaSchemaRegistry
     topicListings(partialTopicName: String): [KafkaTopicListing!]!
     totalTopicCount: Int!
+}
+
+type KafkaConnect {
+    connectId: ID!
+    config: String!
+    name: String!
 }
 
 type KafkaClusterDescription {


### PR DESCRIPTION
Simple example of how to hook up basic GraphQL support.

Please note: The KafkaConnectConfig / KafkaConnect divide is an implementation detail that allows me to separates the input required from a user from the derived fields that will eventually be available for return.