### PR TITLE
fix connection to postgres for default credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: "3"
 services:
   db:
     image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=root
+      - POSTGRES_DB=postgres
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
When cloning the repo and running docker-compose up -d --build
It does not work for grafka_api_1 because the credentials for postgres are missing. When looking in the code for the credentials
in the grafka/grafka project directory in src/main.../resources/application.yml we can see the default credentials used in addition to the connection string defined in this file under services.api.environment